### PR TITLE
[ui] Fix local high score reset in leaderboard on modifiers change

### DIFF
--- a/crates/ctl-local/src/leaderboard.rs
+++ b/crates/ctl-local/src/leaderboard.rs
@@ -561,7 +561,6 @@ impl LeaderboardImpl {
         let fs = self.fs.clone();
         let level_id = LocalLevelId::from_info(&self.loaded.level);
         let version = self.loaded.category.version;
-        self.loaded.local_high = None;
         let task = async move {
             let mut scores = match fs.load_local_scores(&level_id).await {
                 Ok(scores) => scores,


### PR DESCRIPTION
Changing modifiers with the leaderboard open used to change the rating index of the local result to `?`.

I suppose, this change should fix the issue, BUT I did not succeed at building the web version, so I could not test it.